### PR TITLE
shortened curriculum descriptions

### DIFF
--- a/pages/workshops-curricula.md
+++ b/pages/workshops-curricula.md
@@ -9,6 +9,7 @@ permalink: /workshops-curricula/
 * [Data Carpentry: Geospatial](#dc-geospatial)
 * [Data Carpentry: Social Sciences](#dc-socialsci)
 * [Library Carpentry](#lc)
+* [Software Carpentry (All Workshops)](#swc-all)
 * [Software Carpentry (Plotting and Programming in Python)](#swc-plot-python)
 * [Software Carpentry (Programming with Python)](#swc-prog-python)
 * [Software Carpentry (Programming with R)](#swc-prog-R)
@@ -16,30 +17,75 @@ permalink: /workshops-curricula/
 
 
 ### <a id="dc-ecology"></a> Data Carpentry: Ecology
-This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting (with your choice of R or Python). This workshop is intended for anyone working with tabular data (data with rows and columns). The data used for this workshop is an ecology dataset - counts of animal species that were observed in different locations over time, along with information about their sex, weight, etc. This data is easily understandable by non-ecologists and is considered our most general-purpose workshop. 
+This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting (with your
+choice of R or Python). This workshop is intended for anyone working with tabular data (data with rows and columns, e.g. Excel). The data
+used for this workshop is an ecology dataset - counts of animal species that were observed in different locations over time, along with 
+information about their sex, weight, etc. This data is easily understandable by non-ecologists and is considered our most general-purpose
+workshop. 
 
 ### <a id="dc-genomics"></a>Data Carpentry: Genomics
-This workshop is intended for people working with high-throughput sequencing data and focuses on helping them upgrade their workflow from relying on spreadsheets and GUI platforms to using command-line tools and remote computing power. This workshop is taught using Amazon Web Services. Learners will be introduced to core Bash commands and will learn to write custom Bash scripts to automate an analysis pipeline. They will be introduced to some commonly used command-line bioinformatics tools and file formats. This workshop does not cover individual methods for working with RNA-seq, ChIP-seq, or other specialized datasets, but instead focuses on core principles for efficient and reproducible research with sequencing data.
+This workshop is intended for people working with high-throughput sequencing data and focuses on helping them upgrade their workflow from
+relying on spreadsheets and GUI platforms to using command-line tools and remote computing power. This workshop is taught using Amazon 
+Web Services. Learners will be introduced to core Bash commands and will learn to write custom Bash scripts to automate an analysis 
+pipeline. They will be introduced to some commonly used command-line bioinformatics tools and file formats. This workshop does not cover
+individual methods for working with RNA-seq, ChIP-seq, or other specialized datasets, but instead focuses on core principles for 
+efficient and reproducible research with sequencing data.
 
 ### <a id="dc-geospatial"></a>Data Carpentry: Geospatial
-This workshop is intended for people working with geospatial data (i.e. data that can be plotted on a map). It starts out with a short introduction to essential geospatial concepts and a shortened version of our core R lesson before progressing into working with specialized geospatial packages in R. This workshop gets learners to a fairly advanced stage of creating geospatial plots (i.e. maps of data distributions), but does not cover data organisation or cleaning. For a more general workshop covering these topics, please check out our Ecology and Social Sciences curricula.
+This workshop is intended for people working with geospatial data (i.e. data that can be plotted on a map). It starts out with a short
+introduction to essential geospatial concepts and a shortened version of our core R lesson before progressing into working with 
+specialized geospatial packages in R. This workshop gets learners to a fairly advanced stage of creating geospatial plots (i.e. maps of 
+data distributions), but does not cover data organisation or cleaning. For a more general workshop covering these topics, please check 
+out our [Ecology](#dc-ecology) and [Social Sciences](#dc-socialsci) curricula.
 
 ### <a id="dc-socialsci"></a>Data Carpentry: Social Sciences
-This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting with R. This workshop is very similar to our Ecology workshop, but uses a dataset more relevant for social scientists, particularly those working with interview data. The data used for this workshop is a set of interview responses from interviews of farmers in two countries in eastern Africa about their agricultural practices and household resources. This workshop uses restricted-response data and does not cover qualitative data analysis or analysis of free-text responses.
+This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting with R. This
+workshop is very similar to our [Ecology](#dc-ecology) workshop, but uses a dataset more relevant for social scientists, particularly those working with
+interview data. The data used for this workshop is a set of interview responses from interviews of farmers in two countries in eastern 
+Africa about their agricultural practices and household resources. This workshop uses restricted-response data and does not cover 
+qualitative data analysis or analysis of free-text responses.
 
 ### <a id="lc"></a>Library Carpentry
-This workshop is intended for people working in libraries and the information sciences. It introduces terms, phrases, and concepts in software development and data science, how to best work with data structures, and use regular expressions in searches. We introduce the Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands. We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version control to track your work.
+This workshop is intended for people working in libraries and the information sciences. It introduces terms, phrases, and concepts in 
+software development and data science, how to best work with data structures, and use regular expressions in searches. We introduce the 
+Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands. 
+We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we 
+cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version 
+control to track your work.
+
+### <a id="swc-all"></a>Software Carpentry (All Workshops)
+All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of
+either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their
+computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version
+control and be able to implement a simple Git workflow for tracking their own work. Software Carpentry workshops also include your 
+choice of one of our R or Python lessons (listed below).
 
 ### <a id="swc-plot-python"></a>Software Carpentry (Plotting and Programming in Python)
-All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version control and be able to implement a simple Git workflow for tracking their own work. In addition, this workshop covers data analysis and visualisation in Python, focusing on working with core data structures (including tabular data, not covered in our Programming with Python lesson), using conditionals and loops, writing custom functions, and creating customised plots. As our more introductory Python offering, this workshop also introduces learners to JupyterLab and strategies for getting help. This workshop is appropriate for learners with no previous programming experience. For audiences with some experience with Python or other programming languages, we recommend our Programming with Python lesson.
+Our more introductory Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
+visualisation in Python, focusing on working with core data structures (including tabular data, not covered in our Programming with 
+Python lesson), using conditionals and loops, writing custom functions, and creating customised plots. As our more introductory Python 
+offering, this workshop also introduces learners to JupyterLab and strategies for getting help. This workshop is appropriate for learners
+with no previous programming experience. For audiences with some experience with Python or other programming languages, we recommend our
+[Programming with Python](#swc-prog-python) lesson.
 
 ### <a id="swc-prog-python"></a>Software Carpentry (Programming with Python) 
-All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version control and be able to implement a simple Git workflow for tracking their own work. In addition, this workshop covers data analysis and visualisation in Python, focusing on working with core data structures, using conditionals and loops, writing custom functions, and running Python programs from the command line. This is the more advanced of our two Python offerings for Software Carpentry and is appropriate for learners with some previous programming experience, in Python or other languages. For audiences with no previous programming experience, we recommend our Plotting and Programming in Python lesson.
-
-### <a id="swc-prog-R"></a>Software Carpentry (Programming with R)
-All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version control and be able to implement a simple Git workflow for tracking their own work. In addition, this workshop covers data analysis and visualisation in R focusing on working with core data structures, using conditionals and loops, writing custom functions, and running R programs from the command line. This is the more advanced of our two R offerings for Software Carpentry and is appropriate for learners with some previous programming experience, in R or other languages. For audiences with no previous programming experience, we recommend our R for Reproducible Scientific Analysis lesson.
+Our more advanced Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
+visualisation in Python, focusing on working with core data structures, using conditionals and loops, writing custom functions, and 
+running Python programs from the command line. This is the more advanced of our two Python offerings for Software Carpentry and is 
+appropriate for learners with some previous programming experience, in Python or other languages. For audiences with no previous 
+programming experience, we recommend our [Plotting and Programming in Python](#swc-plot-python) lesson.
 
 ### <a id="swc-repro-R"></a>Software Carpentry (R for Reproducible Scientific Analysis)
-All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version control and be able to implement a simple Git workflow for tracking their own work. In addition, this workshop covers data analysis and visualisation in R, focusing on working with tabular data and other core data structures, using conditionals and loops, writing custom functions, and creating publication-quality graphics. As our more introductory R offering, this workshop also introduces learners to RStudio and strategies for getting help. This workshop is appropriate for learners with no previous programming experience. For audiences with some experience with R or other programming languages, we recommend our Programming with R lesson.
+Our more introductory R lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
+visualisation in R, focusing on working with tabular data and other core data structures, using conditionals and loops, writing custom 
+functions, and creating publication-quality graphics. As our more introductory R offering, this workshop also introduces learners to 
+RStudio and strategies for getting help. This workshop is appropriate for learners with no previous programming experience. For audiences
+with some experience with R or other programming languages, we recommend our [Programming with R](#swc-prog-R) lesson.
 
+### <a id="swc-prog-R"></a>Software Carpentry (Programming with R)
+Our more advanced R lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and
+visualisation in R focusing on working with core data structures, using conditionals and loops, writing custom functions, and running R 
+programs from the command line. This is the more advanced of our two R offerings for Software Carpentry and is appropriate for learners 
+with some previous programming experience, in R or other languages. For audiences with no previous programming experience, we recommend 
+our [R for Reproducible Scientific Analysis](#swc-repro-R) lesson.
 


### PR DESCRIPTION
- added line breaks
- reordered two SWC R lessons so they follow same intro --> advanced pattern as Python lessons
- moved cored SWC content to separate section
- added internal links where one description references another workshop description
- added "intro" and "advanced" description at beg of each SWC workshop to make them easier to parse